### PR TITLE
BGDIINF_SB-2357: Fixed semver versioning with `v` prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Github Action to automatically bump and tag master, on merge, with the latest 
 
 [<img src="https://miro.medium.com/max/1200/1*_4Ex1uUhL93a3bHyC-TgPg.png" width="400">](https://itnext.io/creating-a-github-action-to-tag-commits-2722f1560dec)
 
-### Usage
+## Usage
 
 ```Dockerfile
 name: Bump version
@@ -34,9 +34,9 @@ jobs:
 
 _NOTE: set the fetch-depth for `actions/checkout@v2` to be sure you retrieve all commits to look for the semver commit message._
 
-#### Options
+### Options
 
-**Environment Variables**
+#### Environment Variables
 
 - **GITHUB_TOKEN** **_(required)_** - Required for permission to tag the repo.
 - **DEFAULT_BUMP** _(optional)_ - Which type of bump to use when none explicitly provided (default: `minor`).

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,18 +6,17 @@ set -o pipefail
 default_semvar_bump=${DEFAULT_BUMP:-minor}
 with_v=${WITH_V:-false}
 release_branches=${RELEASE_BRANCHES:-master,main}
-custom_tag=${CUSTOM_TAG}
+custom_tag=${CUSTOM_TAG:-}
 source=${SOURCE:-.}
 dryrun=${DRY_RUN:-false}
 initial_version=${INITIAL_VERSION:-0.0.0}
 tag_context=${TAG_CONTEXT:-repo}
 suffix=${PRERELEASE_SUFFIX:-beta}
 verbose=${VERBOSE:-true}
-verbose=${VERBOSE:-true}
 # since https://github.blog/2022-04-12-git-security-vulnerability-announced/ runner uses?
 git config --global --add safe.directory /github/workspace
 
-cd ${GITHUB_WORKSPACE}/${source}
+cd "${GITHUB_WORKSPACE}/${source}" || exit
 
 echo "*** CONFIGURATION ***"
 echo -e "\tDEFAULT_BUMP: ${default_semvar_bump}"
@@ -36,13 +35,13 @@ current_branch=$(git rev-parse --abbrev-ref HEAD)
 pre_release="true"
 IFS=',' read -ra branch <<< "$release_branches"
 for b in "${branch[@]}"; do
-    echo "Is $b a match for ${current_branch}"
-    if [[ "${current_branch}" =~ $b ]]
+    echo "Is ${b} a match for ${current_branch}"
+    if [[ "${current_branch}" =~ ${b} ]]
     then
         pre_release="false"
     fi
 done
-echo "pre_release = $pre_release"
+echo "pre_release = ${pre_release}"
 
 # fetch tags
 git fetch --tags
@@ -71,75 +70,86 @@ esac
 
 
 # if there are none, start tags at INITIAL_VERSION which defaults to 0.0.0
-if [ -z "$tag" ]
+if [[ -z "${tag}" ]]
 then
     log=$(git log --pretty='%B')
-    tag="$initial_version"
-    if [ -z "$pre_tag" ] && $pre_release
+    tag="${initial_version}"
+    if [[ -z "${pre_tag}" ]] && ${pre_release}
     then
-      pre_tag="$initial_version"
+      pre_tag="${initial_version}"
     fi
 else
-    log=$(git log $tag..HEAD --pretty='%B')
+    log=$(git log "${tag}"..HEAD --pretty='%B')
 fi
 
 # get current commit hash for tag
-tag_commit=$(git rev-list -n 1 $tag)
+tag_commit=$(git rev-list -n 1 "${tag}")
 
 # get current commit hash
 commit=$(git rev-parse HEAD)
 
-if [ "$tag_commit" == "$commit" ]; then
+if [[ "${tag_commit}" == "${commit}" ]]
+then
     echo "No new commits since previous tag. Skipping..."
-    echo ::set-output name=tag::$tag
+    echo "::set-output name=tag::${tag}"
     exit 0
 fi
 
 # echo log if verbose is wanted
-if $verbose
+if ${verbose}
 then
-  echo $log
+  echo "${log}"
 fi
 
-case "$log" in
-    *#major* ) new=$(semver -i major $tag); part="major";;
-    *#minor* ) new=$(semver -i minor $tag); part="minor";;
-    *#patch* ) new=$(semver -i patch $tag); part="patch";;
-    *#none* ) 
-        echo "Default bump was set to none. Skipping..."; echo ::set-output name=new_tag::$tag; echo ::set-output name=tag::$tag; exit 0;;
-    * ) 
-        if [ "$default_semvar_bump" == "none" ]; then
-            echo "Default bump was set to none. Skipping..."; echo ::set-output name=new_tag::$tag; echo ::set-output name=tag::$tag; exit 0 
-        else 
-            new=$(semver -i "${default_semvar_bump}" $tag); part=$default_semvar_bump 
-        fi 
+case "${log}" in
+    *#major* ) new=$(semver -i major "${tag}"); part="major";;
+    *#minor* ) new=$(semver -i minor "${tag}"); part="minor";;
+    *#patch* ) new=$(semver -i patch "${tag}"); part="patch";;
+    *#none* )
+        echo "Default bump was set to none. Skipping..."
+        echo "::set-output name=new_tag::${tag}"
+        echo "::set-output name=tag::${tag}"
+        exit 0
+        ;;
+    * )
+        if [[ "${default_semvar_bump}" == "none" ]]
+        then
+            echo "Default bump was set to none. Skipping..."
+            echo "::set-output name=new_tag::${tag}"
+            echo "::set-output name=tag::${tag}"
+            exit 0
+        else
+            new=$(semver -i "${default_semvar_bump}" "${tag}"); part=${default_semvar_bump}
+        fi
         ;;
 esac
 
-if $pre_release
+if ${pre_release}
 then
     # Already a prerelease available, bump it
-    if [[ "$pre_tag" == *"$new"* ]]; then
-        new=$(semver -i prerelease $pre_tag --preid $suffix); part="pre-$part"
+    if [[ "${pre_tag}" == *"${new}"* ]]
+    then
+        new=$(semver -i prerelease "${pre_tag}" --preid "${suffix}"); part="pre-${part}"
     else
-        new="$new-$suffix.1"; part="pre-$part"
+        new="${new}-${suffix}.1"; part="pre-${part}"
     fi
 fi
 
-echo $part
+echo "${part}"
 
 # prefix with 'v'
-if $with_v
+if ${with_v}
 then
 	new="v$new"
 fi
 
-if [ ! -z $custom_tag ]
+if [[ -n "${custom_tag}" ]]
 then
-    new="$custom_tag"
+    echo "Use custom tag ${custom_tag} instead of ${new}"
+    new="${custom_tag}"
 fi
 
-if $pre_release
+if ${pre_release}
 then
     echo -e "Bumping tag ${pre_tag}. \n\tNew tag ${new}"
 else
@@ -147,36 +157,36 @@ else
 fi
 
 # set outputs
-echo ::set-output name=new_tag::$new
-echo ::set-output name=part::$part
+echo "::set-output name=new_tag::${new}"
+echo "::set-output name=part::${part}"
 
 # use dry run to determine the next tag
-if $dryrun
+if ${dryrun}
 then
-    echo ::set-output name=tag::$tag
+    echo "::set-output name=tag::${tag}"
     exit 0
-fi 
+fi
 
-echo ::set-output name=tag::$new
+echo "::set-output name=tag::${new}"
 
 # create local git tag
-git tag $new
+git tag "${new}"
 
 # push new tag ref to github
 dt=$(date '+%Y-%m-%dT%H:%M:%SZ')
-full_name=$GITHUB_REPOSITORY
-git_refs_url=$(jq .repository.git_refs_url $GITHUB_EVENT_PATH | tr -d '"' | sed 's/{\/sha}//g')
+full_name=${GITHUB_REPOSITORY}
+git_refs_url=$(jq .repository.git_refs_url "${GITHUB_EVENT_PATH}" | tr -d '"' | sed 's/{\/sha}//g')
 
-echo "$dt: **pushing tag $new to repo $full_name"
+echo "${dt}: **pushing tag ${new} to repo ${full_name}"
 
 git_refs_response=$(
-curl -s -X POST $git_refs_url \
--H "Authorization: token $GITHUB_TOKEN" \
+curl -s -X POST "${git_refs_url}" \
+-H "Authorization: token ${GITHUB_TOKEN}" \
 -d @- << EOF
 
 {
-  "ref": "refs/tags/$new",
-  "sha": "$commit"
+  "ref": "refs/tags/${new}",
+  "sha": "${commit}"
 }
 EOF
 )
@@ -184,7 +194,8 @@ EOF
 git_ref_posted=$( echo "${git_refs_response}" | jq .ref | tr -d '"' )
 
 echo "::debug::${git_refs_response}"
-if [ "${git_ref_posted}" = "refs/tags/${new}" ]; then
+if [[ "${git_ref_posted}" == "refs/tags/${new}" ]]
+then
   exit 0
 else
   echo "::error::Tag was not created properly."


### PR DESCRIPTION
semver command stripped the v prefix which then broke the logic.

Now if the option WITH_V is given we look only for vx.x.x versions, which
means that if you want to add/remove the v prefix in your existing repository
and want to keep the versioning consistent (e.g, passing from 1.2.0 to v1.3.0,
or passing from v1.2.0 to 1.3.0) you need to set the INITIAL_VERSION accordingly:
 1. Passing from 1.2.0 to v1.3.0 => INITIAL_VERSION=v1.3.0
 2. Passing from v1.2.0 to 1.3.0 => INITIAL_VERSION=1.3.0