### PR TITLE
PB-579: Fixed pre-release tagging

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -105,6 +105,11 @@ then
     fi
 else
     log=$(git log "${tag}"..HEAD --pretty='%B')
+
+    if ${pre_release}
+    then
+        log=$(git log "${pre_tag}"..HEAD --pretty='%B')
+    fi
 fi
 
 # get current commit hash for tag


### PR DESCRIPTION
Pre-released use the logs until the last tag and not until the last pre-release
tag. This mean if you have a pre-release PR that is merged with #patch for example
and then you have another pre-release PR that is merged with the default bump
type of minor, the resulting tag would be a #patch due to previous pre-release.

Now for pre-release we take the previous pre release tag (which can be identical
to the release tag for the first pre-release) to get the logs.